### PR TITLE
Change assertTrue(isinstance()) by optimal assert

### DIFF
--- a/zaqar/tests/unit/storage/base.py
+++ b/zaqar/tests/unit/storage/base.py
@@ -782,7 +782,7 @@ class MessageControllerTest(ControllerBaseTest):
         res = self.controller.bulk_get(queue_name, message_ids,
                                        project=self.project)
 
-        self.assertTrue(isinstance(res, collections.Iterable))
+        self.assertIsInstance(res, collections.Iterable)
         self.assertEqual([], list(res))
 
 


### PR DESCRIPTION
Some of tests use different method of assertTrue(isinstance(A, B))
or assertEqual(type(A), B).
The correct way is to use assertIsInstance(A, B) provided by testtools

Change-Id: I15ff9fdab8cdf098634a48879e8992a59bfa91b2
